### PR TITLE
Add button platform with manual regeneration and error memory reset

### DIFF
--- a/custom_components/gruenbeck_softliQ_SC/__init__.py
+++ b/custom_components/gruenbeck_softliQ_SC/__init__.py
@@ -16,7 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 # For your initial PR, limit it to 1 platform.
 PLATFORMS: list[Platform] = [
     Platform.SENSOR, 
-    Platform.SELECT
+    Platform.SELECT,
+    Platform.BUTTON,  # NEU
 ]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/gruenbeck_softliQ_SC/button.py
+++ b/custom_components/gruenbeck_softliQ_SC/button.py
@@ -1,0 +1,84 @@
+"""Button platform for Gruenbeck SoftliQ SC integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import SoftQLinkDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SoftQLinkButtonEntityDescription(ButtonEntityDescription):
+    """Class describing SoftQLink button entities."""
+
+
+BUTTON_DESCRIPTIONS: tuple[SoftQLinkButtonEntityDescription, ...] = (
+    SoftQLinkButtonEntityDescription(
+        key="manual_regeneration",
+        translation_key="manual_regeneration",
+        icon="mdi:refresh",
+    ),
+    SoftQLinkButtonEntityDescription(
+        key="reset_error_memory",
+        translation_key="reset_error_memory",
+        icon="mdi:alert-remove",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Gruenbeck button entities."""
+    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        SoftQLinkButtonEntity(coordinator, description)
+        for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class SoftQLinkButtonEntity(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], ButtonEntity):
+    """Representation of a SoftQLink button."""
+
+    entity_description: SoftQLinkButtonEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SoftQLinkDataUpdateCoordinator,
+        description: SoftQLinkButtonEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.name}")},
+            name=coordinator.name,
+            manufacturer="Gruenbeck",
+            model=coordinator.clientMuxClient.model,
+            sw_version=coordinator.clientMuxClient.sw_version,
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        try:
+            if self.entity_description.key == "manual_regeneration":
+                await self.coordinator.clientMuxClient.startManualRegeneration()
+            elif self.entity_description.key == "reset_error_memory":
+                await self.coordinator.clientMuxClient.resetErrorMemory()
+        except Exception as e:
+            _LOGGER.error("Gruenbeck button press failed: %s", e)
+            raise

--- a/custom_components/gruenbeck_softliQ_SC/strings.json
+++ b/custom_components/gruenbeck_softliQ_SC/strings.json
@@ -3,13 +3,14 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "name": "[%key:common::config_flow::data::name%]"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
@@ -17,9 +18,100 @@
     }
   },
   "entity": {
+    "sensor": {
+      "D_A_1_1": {
+        "name": "Current flow"
+      },
+      "D_A_1_2": {
+        "name": "remaining capacity"
+      },
+      "D_A_1_3": {
+        "name": "Capacity number"
+      },
+      "D_A_1_7": {
+        "name": "Total flow"
+      },
+      "D_A_2_1": {
+        "name": "Remaining time/quantity regeneration step"
+      },
+      "D_A_2_2": {
+        "name": "days until the next maintenance"
+      },
+      "D_A_2_3": {
+        "name": "Salt range in days"
+      },
+      "D_A_3_1": {
+        "name": "Last regeneration"
+      },
+      "D_A_3_2": {
+        "name": "Percentage regeneration"
+      },
+
+      "D_Y_1": {
+        "name": "Water consumption yesterday"
+      },
+      "D_Y_3": {
+        "name": "Salt consumption per year"
+      },
+      "D_Y_5": {
+        "name": "Current regeneration step",
+        "state": {
+          "0": "No regeneration",
+          "1": "Fill brine tank",
+          "2": "Salting",
+          "3": "Slow rinsing",
+          "4": "Backwashing",
+          "5": "Washing out"
+        }
+      },
+      "D_Y_6": {
+        "name": "Software Version"
+      },
+      "D_K_2": {
+        "name": "Soft water volume meter"
+      },
+      "D_K_3": {
+        "name": "Flow peak value"
+      },
+      "D_F_4": {
+        "name": "System type"
+      },
+      "D_K_5": {
+        "name": "Chlorine current"
+      },
+      "D_K_8": {
+        "name": "Consumption capacity rate"
+      },
+      "D_K_9": {
+        "name": "Average consumption over the last 3 day"
+      },
+      "D_K_10_1": {
+        "name": "Last Error",
+        "state": {
+          "E1": "Malfunction in the drive control valve regeneration",
+          "E4": "Fill salt tablets in the salt tank",
+          "E6": "Water meter regeneration quantity not reached",
+          "E7": "The system sucks out brine in the salt tank too poorly",
+          "EA": "Low salt alert",
+          "EC": "Nominal flow exceeded"
+        }
+      },
+      "D_K_10_1_Hours": {
+        "name": "Last Error hours old"
+      },
+      "D_D_1": {
+        "name": "Raw water hardness"
+      }
+    },
     "select": {
       "D_C_5_1": {
-        "name": "Power mode"
+        "name": "Mode",
+        "state": {
+          "0": "Eco",
+          "1": "Power",
+          "2": "Comfort",
+          "3": "Individual"
+        }
       }
     },
     "button": {

--- a/custom_components/gruenbeck_softliQ_SC/strings.json
+++ b/custom_components/gruenbeck_softliQ_SC/strings.json
@@ -3,14 +3,13 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "host": "[%key:common::config_flow::data::host%]"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
@@ -18,100 +17,17 @@
     }
   },
   "entity": {
-    "sensor": {
-      "D_A_1_1": {
-        "name": "Current flow"
-      },
-      "D_A_1_2": {
-        "name": "remaining capacity"
-      },
-      "D_A_1_3": {
-        "name": "Capacity number"
-      },
-      "D_A_1_7": {
-        "name": "Total flow"
-      },
-      "D_A_2_1": {
-        "name": "Remaining time/quantity regeneration step"
-      },
-      "D_A_2_2": {
-        "name": "days until the next maintenance"
-      },
-      "D_A_2_3": {
-        "name": "Salt range in days"
-      },
-      "D_A_3_1": {
-        "name": "Last regeneration"
-      },
-      "D_A_3_2": {
-        "name": "Percentage regeneration"
-      },
-
-      "D_Y_1": {
-        "name": "Water consumption yesterday"
-      },
-      "D_Y_3": {
-        "name": "Salt consumption per year"
-      },
-      "D_Y_5": {
-        "name": "Current regeneration step",
-        "state": {
-          "0": "No regeneration",
-          "1": "Fill brine tank",
-          "2": "Salting",
-          "3": "Slow rinsing",
-          "4": "Backwashing",
-          "5": "Washing out"
-        }
-      },
-      "D_Y_6": {
-        "name": "Software Version"
-      },
-      "D_K_2": {
-        "name": "Soft water volume meter"
-      },
-      "D_K_3": {
-        "name": "Flow peak value"
-      },
-      "D_F_4": {
-        "name": "System type"
-      },
-      "D_K_5": {
-        "name": "Chlorine current"
-      },
-      "D_K_8": {
-        "name": "Consumption capacity rate"
-      },
-      "D_K_9": {
-        "name": "Average consumption over the last 3 day"
-      },
-      "D_K_10_1": {
-        "name": "Last Error",
-        "state": {
-          "E1": "Malfunction in the drive control valve regeneration",
-          "E4": "Fill salt tablets in the salt tank",
-          "E6": "Water meter regeneration quantity not reached",
-          "E7": "The system sucks out brine in the salt tank too poorly",
-          "EA": "Low salt alert",
-          "EC": "Nominal flow exceeded"
-        }
-      },
-      "D_K_10_1_Hours": {
-        "name": "Last Error hours old"
-      },
-      "D_D_1": {
-        "name": "Raw water hardness"
-      }
-    },
     "select": {
       "D_C_5_1": {
-        "name": "Mode",
-        "state": {
-          "0": "Eco",
-          "1": "Power",
-          "2": "Comfort",
-          "3": "Individual"
-        }
+        "name": "Power mode"
+      }
+    },
+    "button": {
+      "manual_regeneration": {
+        "name": "Manual regeneration"
+      },
+      "reset_error_memory": {
+        "name": "Reset error memory"
       }
     }
   }

--- a/custom_components/gruenbeck_softliQ_SC/translations/de.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/de.json
@@ -1,34 +1,128 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "host": "Host"
+    "config": {
+        "abort": {
+            "already_configured": "Gerät ist bereits konfiguriert"
+        },
+        "error": {
+            "cannot_connect": "Verbindung fehlgeschlagen",
+            "invalid_auth": "Ungültige Authentifizierung",
+            "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "name": "Name"
+                }
+            }
         }
-      }
     },
-    "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen",
-      "invalid_host": "Ungültiger Hostname oder IP-Adresse",
-      "unknown": "Unbekannter Fehler"
-    },
-    "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+    "entity": {
+        "sensor": {
+            "D_A_1_1": {
+                "name": "Aktueller Durchfluss"
+            },
+            "D_A_1_2": {
+                "name": "Verbleibende Kapazität"
+            },
+            "D_A_1_3": {
+                "name": "Kapazitätsnummer"
+            },
+            "D_A_1_7": {
+                "name": "Gesamtdurchfluss"
+            },
+            "D_A_2_1": {
+                "name": "Verbleibende Zeit/Menge des Regenerationsschritts"
+            },
+            "D_A_2_2": {
+                "name": "Tage bis zur nächsten Wartung"
+            },
+            "D_A_2_3": {
+                "name": "Salzreichweite in Tagen"
+            },
+            "D_A_3_1": {
+                "name": "Letzte Regeneration"
+            },
+            "D_A_3_2": {
+                "name": "Prozentuale Regeneration"
+            },
+            "D_Y_1": {
+                "name": "Wasserverbrauch gestern"
+            },
+            "D_Y_3": {
+                "name": "Salzverbrauch pro Jahr"
+            },
+            "D_Y_5": {
+                "name": "Aktueller Regenerationsschritt",
+                "state": {
+                    "0": "Keine Regeneration",
+                    "1": "Salztank füllen",
+                    "2": "Salzung",
+                    "3": "Langsames Spülen",
+                    "4": "Rückspülen",
+                    "5": "Ausspülen"
+                }
+            },
+            "D_Y_6": {
+                "name": "Software-Version"
+            },
+            "D_K_2": {
+                "name": "Weichwasservolumenmesser"
+            },
+            "total_consumption": {
+                "name": "Gesamtverbrauch"
+            },
+            "D_K_3": {
+                "name": "Flussspitzenwert"
+            },
+            "D_F_4": {
+                "name": "Systemtyp"
+            },
+            "D_K_5":{
+                "name":"Chlorstrom"
+            },
+            "D_K_8": {
+                "name": "Verbrauchskapazitätsrate"
+            },
+            "D_K_9": {
+                "name": "Durchschnittsverbrauch der letzten 3 Tage"
+            },
+            "D_K_10_1": {
+                "name": "Letzter Fehler",
+                "state": {
+                    "E1": "Fehlfunktion im Antriebsregelventil der Regeneration",
+                    "E4": "Salztabletten im Salztank nachfüllen",
+                    "E6": "Regenerationsmenge des Wassermessers nicht erreicht",
+                    "E7": "Das System saugt Brine im Salztank zu schlecht ab",
+                    "EA": "Warnung bei niedrigem Salzgehalt",
+                    "EC": "Nennfluss überschritten"
+                }
+            },
+            "D_K_10_1_Hours": {
+                "name": "Letzter Fehler Stunden alt"
+            },
+            "D_D_1": {
+                "name": "Rohwasserhärte"
+            }
+        },
+        "select":{
+            "D_C_5_1": {
+                "name": "Modus",
+                "state": {
+                    "0": "Eco",
+                    "1": "Power",
+                    "2": "Komfort",
+                    "3": "Individuell"
+                }
+            }
+        },
+        "button": {
+            "manual_regeneration": {
+                "name": "Manuelle Regeneration"
+            },
+            "reset_error_memory": {
+                "name": "Fehlerspeicher zurücksetzen"
+            }
+        }
     }
-  },
-  "entity": {
-    "select": {
-      "D_C_5_1": {
-        "name": "Betriebsmodus"
-      }
-    },
-    "button": {
-      "manual_regeneration": {
-        "name": "Manuelle Regeneration"
-      },
-      "reset_error_memory": {
-        "name": "Fehlerspeicher zurücksetzen"
-      }
-    }
-  }
 }

--- a/custom_components/gruenbeck_softliQ_SC/translations/de.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/de.json
@@ -1,120 +1,34 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Gerät ist bereits konfiguriert"
-        },
-        "error": {
-            "cannot_connect": "Verbindung fehlgeschlagen",
-            "invalid_auth": "Ungültige Authentifizierung",
-            "unknown": "Unerwarteter Fehler"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "host": "Host",
-                    "name": "Name"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host"
         }
+      }
     },
-    "entity": {
-        "sensor": {
-            "D_A_1_1": {
-                "name": "Aktueller Durchfluss"
-            },
-            "D_A_1_2": {
-                "name": "Verbleibende Kapazität"
-            },
-            "D_A_1_3": {
-                "name": "Kapazitätsnummer"
-            },
-            "D_A_1_7": {
-                "name": "Gesamtdurchfluss"
-            },
-            "D_A_2_1": {
-                "name": "Verbleibende Zeit/Menge des Regenerationsschritts"
-            },
-            "D_A_2_2": {
-                "name": "Tage bis zur nächsten Wartung"
-            },
-            "D_A_2_3": {
-                "name": "Salzreichweite in Tagen"
-            },
-            "D_A_3_1": {
-                "name": "Letzte Regeneration"
-            },
-            "D_A_3_2": {
-                "name": "Prozentuale Regeneration"
-            },
-            "D_Y_1": {
-                "name": "Wasserverbrauch gestern"
-            },
-            "D_Y_3": {
-                "name": "Salzverbrauch pro Jahr"
-            },
-            "D_Y_5": {
-                "name": "Aktueller Regenerationsschritt",
-                "state": {
-                    "0": "Keine Regeneration",
-                    "1": "Salztank füllen",
-                    "2": "Salzung",
-                    "3": "Langsames Spülen",
-                    "4": "Rückspülen",
-                    "5": "Ausspülen"
-                }
-            },
-            "D_Y_6": {
-                "name": "Software-Version"
-            },
-            "D_K_2": {
-                "name": "Weichwasservolumenmesser"
-            },
-            "total_consumption": {
-                "name": "Gesamtverbrauch"
-            },
-            "D_K_3": {
-                "name": "Flussspitzenwert"
-            },
-            "D_F_4": {
-                "name": "Systemtyp"
-            },
-            "D_K_5":{
-                "name":"Chlorstrom"
-            },
-            "D_K_8": {
-                "name": "Verbrauchskapazitätsrate"
-            },
-            "D_K_9": {
-                "name": "Durchschnittsverbrauch der letzten 3 Tage"
-            },
-            "D_K_10_1": {
-                "name": "Letzter Fehler",
-                "state": {
-                    "E1": "Fehlfunktion im Antriebsregelventil der Regeneration",
-                    "E4": "Salztabletten im Salztank nachfüllen",
-                    "E6": "Regenerationsmenge des Wassermessers nicht erreicht",
-                    "E7": "Das System saugt Brine im Salztank zu schlecht ab",
-                    "EA": "Warnung bei niedrigem Salzgehalt",
-                    "EC": "Nennfluss überschritten"
-                }
-            },
-            "D_K_10_1_Hours": {
-                "name": "Letzter Fehler Stunden alt"
-            },
-            "D_D_1": {
-                "name": "Rohwasserhärte"
-            }
-        },
-        "select":{
-            "D_C_5_1": {
-                "name": "Modus",
-                "state": {
-                    "0": "Eco",
-                    "1": "Power",
-                    "2": "Komfort",
-                    "3": "Individuell"
-                }
-            }
-        }
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_host": "Ungültiger Hostname oder IP-Adresse",
+      "unknown": "Unbekannter Fehler"
+    },
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert"
     }
+  },
+  "entity": {
+    "select": {
+      "D_C_5_1": {
+        "name": "Betriebsmodus"
+      }
+    },
+    "button": {
+      "manual_regeneration": {
+        "name": "Manuelle Regeneration"
+      },
+      "reset_error_memory": {
+        "name": "Fehlerspeicher zurücksetzen"
+      }
+    }
+  }
 }

--- a/custom_components/gruenbeck_softliQ_SC/translations/en.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/en.json
@@ -1,119 +1,33 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "Device is already configured"
-    },
-    "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
-    },
     "step": {
       "user": {
         "data": {
-          "host": "Host",
-          "name": "Name"
+          "host": "Host"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_host": "Invalid hostname or IP address",
+      "unknown": "Unknown error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
   },
   "entity": {
-    "sensor": {
-      "D_A_1_1": {
-        "name": "Current flow"
-      },
-      "D_A_1_2": {
-        "name": "remaining capacity"
-      },
-      "D_A_1_3": {
-        "name": "Capacity number"
-      },
-      "D_A_1_7": {
-        "name": "Total flow"
-      },
-      "D_A_2_1": {
-        "name": "Remaining time/quantity regeneration step"
-      },
-      "D_A_2_2": {
-        "name": "days until the next maintenance"
-      },
-      "D_A_2_3": {
-        "name": "Salt range in days"
-      },
-      "D_A_3_1": {
-        "name": "Last regeneration"
-      },
-      "D_A_3_2": {
-        "name": "Percentage regeneration"
-      },
-      "D_Y_1": {
-        "name": "Water consumption yesterday"
-      },
-      "D_Y_3": {
-        "name": "Salt consumption per year"
-      },
-      "D_Y_5": {
-        "name": "Current regeneration step",
-        "state": {
-          "0": "No regeneration",
-          "1": "Fill brine tank",
-          "2": "Salting",
-          "3": "Slow rinsing",
-          "4": "Backwashing",
-          "5": "Washing out"
-        }
-      },
-      "D_Y_6": {
-        "name": "Software Version"
-      },
-      "D_K_2": {
-        "name": "Soft water volume meter"
-      },
-      "total_consumption": {
-        "name": "Total consumption"
-      },
-      "D_K_3": {
-        "name": "Flow peak value"
-      },
-      "D_F_4": {
-        "name": "System type"
-      },
-      "D_K_5": {
-        "name": "Chlorine current"
-      },
-      "D_K_8": {
-        "name": "Consumption capacity rate"
-      },
-      "D_K_9": {
-        "name": "Average consumption over the last 3 day"
-      },
-      "D_K_10_1": {
-        "name": "Last Error",
-        "state": {
-          "E1": "Malfunction in the drive control valve regeneration",
-          "E4": "Fill salt tablets in the salt tank",
-          "E6": "Water meter regeneration quantity not reached",
-          "E7": "The system sucks out brine in the salt tank too poorly",
-          "EA": "Low salt alert",
-          "EC": "Nominal flow exceeded"
-        }
-      },
-      "D_K_10_1_Hours": {
-        "name": "Last Error hours old"
-      },
-      "D_D_1": {
-        "name": "Raw water hardness"
-      }
-    },
     "select": {
       "D_C_5_1": {
-        "name": "Mode",
-        "state": {
-          "0": "Eco",
-          "1": "Power",
-          "2": "Comfort",
-          "3": "Individual"
-        }
+        "name": "Power mode"
+      }
+    },
+    "button": {
+      "manual_regeneration": {
+        "name": "Manual regeneration"
+      },
+      "reset_error_memory": {
+        "name": "Reset error memory"
       }
     }
   }

--- a/custom_components/gruenbeck_softliQ_SC/translations/en.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/en.json
@@ -1,25 +1,119 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "data": {
-          "host": "Host"
-        }
-      }
+    "abort": {
+      "already_configured": "Device is already configured"
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "invalid_host": "Invalid hostname or IP address",
-      "unknown": "Unknown error"
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
-    "abort": {
-      "already_configured": "Device is already configured"
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host",
+          "name": "Name"
+        }
+      }
     }
   },
   "entity": {
+    "sensor": {
+      "D_A_1_1": {
+        "name": "Current flow"
+      },
+      "D_A_1_2": {
+        "name": "remaining capacity"
+      },
+      "D_A_1_3": {
+        "name": "Capacity number"
+      },
+      "D_A_1_7": {
+        "name": "Total flow"
+      },
+      "D_A_2_1": {
+        "name": "Remaining time/quantity regeneration step"
+      },
+      "D_A_2_2": {
+        "name": "days until the next maintenance"
+      },
+      "D_A_2_3": {
+        "name": "Salt range in days"
+      },
+      "D_A_3_1": {
+        "name": "Last regeneration"
+      },
+      "D_A_3_2": {
+        "name": "Percentage regeneration"
+      },
+      "D_Y_1": {
+        "name": "Water consumption yesterday"
+      },
+      "D_Y_3": {
+        "name": "Salt consumption per year"
+      },
+      "D_Y_5": {
+        "name": "Current regeneration step",
+        "state": {
+          "0": "No regeneration",
+          "1": "Fill brine tank",
+          "2": "Salting",
+          "3": "Slow rinsing",
+          "4": "Backwashing",
+          "5": "Washing out"
+        }
+      },
+      "D_Y_6": {
+        "name": "Software Version"
+      },
+      "D_K_2": {
+        "name": "Soft water volume meter"
+      },
+      "total_consumption": {
+        "name": "Total consumption"
+      },
+      "D_K_3": {
+        "name": "Flow peak value"
+      },
+      "D_F_4": {
+        "name": "System type"
+      },
+      "D_K_5": {
+        "name": "Chlorine current"
+      },
+      "D_K_8": {
+        "name": "Consumption capacity rate"
+      },
+      "D_K_9": {
+        "name": "Average consumption over the last 3 day"
+      },
+      "D_K_10_1": {
+        "name": "Last Error",
+        "state": {
+          "E1": "Malfunction in the drive control valve regeneration",
+          "E4": "Fill salt tablets in the salt tank",
+          "E6": "Water meter regeneration quantity not reached",
+          "E7": "The system sucks out brine in the salt tank too poorly",
+          "EA": "Low salt alert",
+          "EC": "Nominal flow exceeded"
+        }
+      },
+      "D_K_10_1_Hours": {
+        "name": "Last Error hours old"
+      },
+      "D_D_1": {
+        "name": "Raw water hardness"
+      }
+    },
     "select": {
       "D_C_5_1": {
-        "name": "Power mode"
+        "name": "Mode",
+        "state": {
+          "0": "Eco",
+          "1": "Power",
+          "2": "Comfort",
+          "3": "Individual"
+        }
       }
     },
     "button": {


### PR DESCRIPTION
**Manual Regeneration Button**: Triggers an immediate regeneration cycle
 **Error Memory Reset Button**: Clears the device error memory

Modified Files
- `__init__.py` - Added `Platform.BUTTON` to PLATFORMS list
- `softQLinkMuxClient.py` - Added:
  - `asyncio.Lock()` to serialize HTTP requests (device only accepts one connection at a time)
  - `startManualRegeneration()` method - sends parameter `D_B_1>1`
  - `resetErrorMemory()` method - sends parameter `D_M_3_3>1` 
  
The device may close the connection after accepting write commands (`ServerDisconnectedError`), which is handled as normal behavior.

- ✅ Tested on Grünbeck SoftliQ SC18
- ✅ Manual regeneration confirmed working (device starts regeneration cycle)
- ✅ Error memory reset confirmed working
- ✅ No conflicts with coordinator polling
- ✅ Backward compatible - no breaking changes