### PR TITLE
Release/v0.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-executables-have-shebangs
+        stages: [manual]
+      - id: check-json
+        exclude: (.vscode|.devcontainer)
+      - id: no-commit-to-branch
+        args:
+          - --branch=main

--- a/custom_components/gruenbeck_softliQ_SC/__init__.py
+++ b/custom_components/gruenbeck_softliQ_SC/__init__.py
@@ -15,9 +15,10 @@ from .softQLinkMuxClient import SoftQLinkMuxClient
 _LOGGER = logging.getLogger(__name__)
 # For your initial PR, limit it to 1 platform.
 PLATFORMS: list[Platform] = [
-    Platform.SENSOR, 
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
     Platform.SELECT,
-    Platform.BUTTON,  # NEU
+    Platform.BUTTON,
 ]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/gruenbeck_softliQ_SC/__init__.py
+++ b/custom_components/gruenbeck_softliQ_SC/__init__.py
@@ -27,10 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Gruenbeck Water softener local from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
-    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
     websession = async_get_clientsession(hass)
     muxClient = await SoftQLinkMuxClient.create(entry.data[CONF_HOST], websession)
-    coordinator = SoftQLinkDataUpdateCoordinator(hass, entry.title, muxClient)
+    coordinator = SoftQLinkDataUpdateCoordinator(hass, entry, muxClient)
     await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/gruenbeck_softliQ_SC/__init__.py
+++ b/custom_components/gruenbeck_softliQ_SC/__init__.py
@@ -1,4 +1,5 @@
 """The Gruenbeck Water softener local integration."""
+
 from __future__ import annotations
 
 import logging
@@ -20,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.BUTTON,
 ]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Gruenbeck Water softener local from a config entry."""
@@ -43,16 +45,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return unload_ok
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
-        """Migrate old entry."""
-         
-        if config_entry.version > CURRENT_VERSION:
-            _LOGGER.fatal("entities found have a higher version than the integration version")
-            # This means the user has downgraded from a future version
-            return False
 
-        if config_entry.version < CURRENT_VERSION:
-            new_data = {**config_entry.data} 
-            hass.config_entries.async_update_entry(config_entry, data=new_data, minor_version=0, version= CURRENT_VERSION)
-      
-        return True
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Migrate old entry."""
+
+    if config_entry.version > CURRENT_VERSION:
+        _LOGGER.fatal(
+            "entities found have a higher version than the integration version"
+        )
+        # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version < CURRENT_VERSION:
+        new_data = {**config_entry.data}
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, minor_version=0, version=CURRENT_VERSION
+        )
+
+    return True

--- a/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
+++ b/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
@@ -1,0 +1,86 @@
+"""Binary sensor platform for Gruenbeck SoftliQ SC integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import SoftQLinkDataUpdateCoordinator
+
+
+@dataclass(frozen=True)
+class SoftQLinkBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing SoftQLink binary sensor entities."""
+
+
+BINARY_SENSOR_DESCRIPTIONS: tuple[SoftQLinkBinarySensorEntityDescription, ...] = (
+    SoftQLinkBinarySensorEntityDescription(
+        key="regeneration_running",
+        translation_key="regeneration_running",
+        icon="mdi:water-sync",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Gruenbeck binary sensor entities."""
+    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        SoftQLinkBinarySensor(coordinator, description)
+        for description in BINARY_SENSOR_DESCRIPTIONS
+    )
+
+
+class SoftQLinkBinarySensor(
+    CoordinatorEntity[SoftQLinkDataUpdateCoordinator], BinarySensorEntity
+):
+    """Representation of a SoftQLink binary sensor."""
+
+    entity_description: SoftQLinkBinarySensorEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SoftQLinkDataUpdateCoordinator,
+        description: SoftQLinkBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.name}")},
+            name=coordinator.name,
+            manufacturer="Gruenbeck",
+            model=coordinator.clientMuxClient.model,
+            sw_version=coordinator.clientMuxClient.sw_version,
+        )
+        self._update_attrs()
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return super().available and "D_B_1" in self.coordinator.data
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_attrs()
+        self.async_write_ha_state()
+
+    def _update_attrs(self) -> None:
+        """Update the entity state from coordinator data."""
+        self._attr_is_on = self.coordinator.data.get("D_B_1") == "1"

--- a/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
+++ b/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for Gruenbeck SoftliQ SC integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -37,7 +38,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Gruenbeck binary sensor entities."""
-    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
     async_add_entities(
         SoftQLinkBinarySensor(coordinator, description)
         for description in BINARY_SENSOR_DESCRIPTIONS

--- a/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
+++ b/custom_components/gruenbeck_softliQ_SC/binary_sensor.py
@@ -10,12 +10,12 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import SoftQLinkDataUpdateCoordinator
+from .entity import build_device_info, get_entity_unique_id_prefix
 
 
 @dataclass(frozen=True)
@@ -63,14 +63,9 @@ class SoftQLinkBinarySensor(
         """Initialize the binary sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.name}")},
-            name=coordinator.name,
-            manufacturer="Gruenbeck",
-            model=coordinator.clientMuxClient.model,
-            sw_version=coordinator.clientMuxClient.sw_version,
-        )
+        unique_id_prefix = get_entity_unique_id_prefix(coordinator)
+        self._attr_unique_id = f"{unique_id_prefix}-{description.key}".lower()
+        self._attr_device_info = build_device_info(coordinator)
         self._update_attrs()
 
     @property

--- a/custom_components/gruenbeck_softliQ_SC/button.py
+++ b/custom_components/gruenbeck_softliQ_SC/button.py
@@ -1,4 +1,5 @@
 """Button platform for Gruenbeck SoftliQ SC integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -43,14 +44,18 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Gruenbeck button entities."""
-    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: SoftQLinkDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
     async_add_entities(
         SoftQLinkButtonEntity(coordinator, description)
         for description in BUTTON_DESCRIPTIONS
     )
 
 
-class SoftQLinkButtonEntity(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], ButtonEntity):
+class SoftQLinkButtonEntity(
+    CoordinatorEntity[SoftQLinkDataUpdateCoordinator], ButtonEntity
+):
     """Representation of a SoftQLink button."""
 
     entity_description: SoftQLinkButtonEntityDescription

--- a/custom_components/gruenbeck_softliQ_SC/button.py
+++ b/custom_components/gruenbeck_softliQ_SC/button.py
@@ -9,12 +9,12 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import SoftQLinkDataUpdateCoordinator
+from .entity import build_device_info, get_entity_unique_id_prefix
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,19 +69,16 @@ class SoftQLinkButtonEntity(
         """Initialize."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.name}")},
-            name=coordinator.name,
-            manufacturer="Gruenbeck",
-            model=coordinator.clientMuxClient.model,
-            sw_version=coordinator.clientMuxClient.sw_version,
-        )
+        unique_id_prefix = get_entity_unique_id_prefix(coordinator)
+        self._attr_unique_id = f"{unique_id_prefix}-{description.key}".lower()
+        self._attr_device_info = build_device_info(coordinator)
 
     @property
     def available(self) -> bool:
         """Return if the button is available."""
         if not super().available:
+            return False
+        if self.coordinator.button_action_in_progress:
             return False
         if self.entity_description.key != "manual_regeneration":
             return True
@@ -90,13 +87,21 @@ class SoftQLinkButtonEntity(
     async def async_press(self) -> None:
         """Handle the button press."""
         try:
+            if self.coordinator.button_action_in_progress:
+                raise HomeAssistantError("Another button action is already running")
             if self.entity_description.key == "manual_regeneration":
                 if self.coordinator.data.get("D_B_1") != "0":
                     raise HomeAssistantError("Manual regeneration is already running")
-                await self.coordinator.clientMuxClient.startManualRegeneration()
+                self.coordinator.set_active_button_action(self.entity_description.key)
+                await self.coordinator.client.start_manual_regeneration()
                 await self.coordinator.async_request_refresh()
             elif self.entity_description.key == "reset_error_memory":
-                await self.coordinator.clientMuxClient.resetErrorMemory()
+                self.coordinator.set_active_button_action(self.entity_description.key)
+                await self.coordinator.client.reset_error_memory()
+                await self.coordinator.async_request_refresh()
         except Exception as e:
             _LOGGER.error("Gruenbeck button press failed: %s", e)
             raise
+        finally:
+            if self.coordinator.active_button_key == self.entity_description.key:
+                self.coordinator.set_active_button_action(None)

--- a/custom_components/gruenbeck_softliQ_SC/button.py
+++ b/custom_components/gruenbeck_softliQ_SC/button.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -72,11 +73,23 @@ class SoftQLinkButtonEntity(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], B
             sw_version=coordinator.clientMuxClient.sw_version,
         )
 
+    @property
+    def available(self) -> bool:
+        """Return if the button is available."""
+        if not super().available:
+            return False
+        if self.entity_description.key != "manual_regeneration":
+            return True
+        return self.coordinator.data.get("D_B_1") == "0"
+
     async def async_press(self) -> None:
         """Handle the button press."""
         try:
             if self.entity_description.key == "manual_regeneration":
+                if self.coordinator.data.get("D_B_1") != "0":
+                    raise HomeAssistantError("Manual regeneration is already running")
                 await self.coordinator.clientMuxClient.startManualRegeneration()
+                await self.coordinator.async_request_refresh()
             elif self.entity_description.key == "reset_error_memory":
                 await self.coordinator.clientMuxClient.resetErrorMemory()
         except Exception as e:

--- a/custom_components/gruenbeck_softliQ_SC/config_flow.py
+++ b/custom_components/gruenbeck_softliQ_SC/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Gruenbeck Water softener local integration."""
+
 from __future__ import annotations
 
 import logging
@@ -14,7 +15,6 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN, CURRENT_VERSION
 from .softQLinkMuxClient import SoftQLinkMuxClient
@@ -78,8 +78,6 @@ class GruenBeckConfigFlow(ConfigFlow, domain=DOMAIN):
         for old_entry in old_entries:
             _LOGGER.warning("Migrating config entry from %s to %s", OLD_DOMAIN, DOMAIN)
 
-             
-
             # Re-create the entry manually under the new domain
             migrated_entry = ConfigEntry(
                 version=old_entry.version,
@@ -101,7 +99,9 @@ class GruenBeckConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.info("Removed old config entry: %s", old_entry.entry_id)
             await self.hass.config_entries.async_remove(old_entry.entry_id)
             _LOGGER.info(
-                "Re-registered config entry %s under new domain %s", migrated_entry.entry_id, DOMAIN
+                "Re-registered config entry %s under new domain %s",
+                migrated_entry.entry_id,
+                DOMAIN,
             )
             await self.hass.config_entries.async_add(migrated_entry)
         return ConfigFlowResult(

--- a/custom_components/gruenbeck_softliQ_SC/config_flow.py
+++ b/custom_components/gruenbeck_softliQ_SC/config_flow.py
@@ -10,14 +10,14 @@ import aiohttp
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.data_entry_flow import FlowResultType
 
 from .const import DOMAIN, CURRENT_VERSION
-from .softQLinkMuxClient import SoftQLinkMuxClient
+from .softQLinkMuxClient import SoftQLinkClientError, SoftQLinkMuxClient
 
 _LOGGER = logging.getLogger(__name__)
 OLD_DOMAIN = "gruenbeck_softliQ_SC"
@@ -36,8 +36,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> bool:
     """
 
     websession: aiohttp.ClientSession = async_get_clientsession(hass)
-    muxClient = await SoftQLinkMuxClient.create(data[CONF_HOST], websession)
-    if not muxClient.connected:
+    mux_client = await SoftQLinkMuxClient.create(data[CONF_HOST], websession)
+    if not mux_client.connected:
         raise CannotConnect
     return True
 
@@ -51,11 +51,24 @@ class GruenBeckConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
+        if user_input is None:
+            if old_entries := self.hass.config_entries.async_entries(OLD_DOMAIN):
+                return await self._async_migrate_old_entry(old_entries[0])
+
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
+                await self.async_set_unique_id(user_input[CONF_HOST].lower())
+                self._abort_if_unique_id_configured()
                 await validate_input(self.hass, user_input)
             except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except SoftQLinkClientError as err:
+                _LOGGER.debug(
+                    "Validation failed for host %s: %s",
+                    user_input[CONF_HOST],
+                    err,
+                )
                 errors["base"] = "cannot_connect"
             except Exception as e:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception: %s", str(e))
@@ -64,46 +77,43 @@ class GruenBeckConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=user_input[CONF_NAME], data=user_input
                 )
-        old_entries = self.hass.config_entries.async_entries(OLD_DOMAIN)
-        if old_entries:
-            return await self._migrate_from_other_domain(old_entries)
-        else:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-            )
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
 
-    async def _migrate_from_other_domain(
-        self, old_entries: list[ConfigEntry[Any]]
+    async def _async_migrate_old_entry(
+        self, old_entry: ConfigEntry[Any]
     ) -> ConfigFlowResult:
-        for old_entry in old_entries:
-            _LOGGER.warning("Migrating config entry from %s to %s", OLD_DOMAIN, DOMAIN)
-
-            # Re-create the entry manually under the new domain
-            migrated_entry = ConfigEntry(
-                version=old_entry.version,
-                domain=DOMAIN,
-                title=old_entry.title,
-                data=dict(old_entry.data),
-                options=dict(old_entry.options),
-                source=old_entry.source,
-                entry_id=old_entry.entry_id,
-                unique_id=old_entry.unique_id,
-                discovery_keys=old_entry.discovery_keys,
-                subentries_data=None,
-                minor_version=old_entry.minor_version,
+        """Re-register a legacy config entry under the new domain."""
+        host = old_entry.data.get(CONF_HOST)
+        if not host:
+            _LOGGER.warning(
+                "Skipping migration of legacy entry %s because host is missing",
+                old_entry.entry_id,
+            )
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_USER_DATA_SCHEMA,
             )
 
-            # Remove the old entry from the registry
-            old_entry.discovery_keys = MappingProxyType({})
+        migrated_entry = ConfigEntry(
+            version=old_entry.version,
+            domain=DOMAIN,
+            title=old_entry.title,
+            data=dict(old_entry.data),
+            options=dict(old_entry.options),
+            source=old_entry.source,
+            entry_id=old_entry.entry_id,
+            unique_id=old_entry.unique_id or host.lower(),
+            discovery_keys=old_entry.discovery_keys,
+            subentries_data=None,
+            minor_version=old_entry.minor_version,
+        )
 
-            _LOGGER.info("Removed old config entry: %s", old_entry.entry_id)
-            await self.hass.config_entries.async_remove(old_entry.entry_id)
-            _LOGGER.info(
-                "Re-registered config entry %s under new domain %s",
-                migrated_entry.entry_id,
-                DOMAIN,
-            )
-            await self.hass.config_entries.async_add(migrated_entry)
+        old_entry.discovery_keys = MappingProxyType({})
+        await self.hass.config_entries.async_remove(old_entry.entry_id)
+        await self.hass.config_entries.async_add(migrated_entry)
+
         return ConfigFlowResult(
             step_id="user",
             type=FlowResultType.SHOW_PROGRESS_DONE,

--- a/custom_components/gruenbeck_softliQ_SC/const.py
+++ b/custom_components/gruenbeck_softliQ_SC/const.py
@@ -1,4 +1,5 @@
 """Constants for the Gruenbeck Water softener local integration."""
+
 from typing import Final
 
 DOMAIN: Final = "gruenbeck_softliq_sc"

--- a/custom_components/gruenbeck_softliQ_SC/const.py
+++ b/custom_components/gruenbeck_softliQ_SC/const.py
@@ -6,3 +6,4 @@ DOMAIN: Final = "gruenbeck_softliq_sc"
 UPDATE_INTERVAL: Final = 5
 TOTAL_CONSUMPTION = "total_consumption"
 CURRENT_VERSION = 2
+REQUEST_TIMEOUT = 5

--- a/custom_components/gruenbeck_softliQ_SC/coordinator.py
+++ b/custom_components/gruenbeck_softliQ_SC/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinator for the Gruenbeck integration."""
+
 from datetime import timedelta
 import logging
 from typing import Any

--- a/custom_components/gruenbeck_softliQ_SC/coordinator.py
+++ b/custom_components/gruenbeck_softliQ_SC/coordinator.py
@@ -4,13 +4,12 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from aiohttp.client_exceptions import ClientError
-
-from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import UPDATE_INTERVAL
-from .softQLinkMuxClient import SoftQLinkMuxClient
+from .softQLinkMuxClient import SoftQLinkClientError, SoftQLinkMuxClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,24 +18,37 @@ class SoftQLinkDataUpdateCoordinator(DataUpdateCoordinator):
     """Define an object to hold softQlink data."""
 
     def __init__(
-        self, hass: HomeAssistant, name: str, muxClient: SoftQLinkMuxClient
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        mux_client: SoftQLinkMuxClient,
     ) -> None:
         """Initialize."""
-        self.name = name
+        self.config_entry = config_entry
         self.datacache: dict[str, Any] = {}
-        self.clientMuxClient = muxClient
+        self.client = mux_client
+        self.button_action_in_progress = False
+        self.active_button_key: str | None = None
         super().__init__(
             hass,
             _LOGGER,
-            name=name,
+            config_entry=config_entry,
+            name=config_entry.title,
             update_interval=timedelta(seconds=UPDATE_INTERVAL),
         )
 
+    @callback
+    def set_active_button_action(self, button_key: str | None) -> None:
+        """Update the transient button-action state and notify entities."""
+        self.button_action_in_progress = button_key is not None
+        self.active_button_key = button_key
+        self.async_update_listeners()
+
     async def _async_update_data(self) -> dict[str, Any]:
         try:
-            self.datacache = (await self.clientMuxClient.getCurrentValues()) | (
-                await self.clientMuxClient.getMeterValues()
+            self.datacache = (await self.client.get_current_values()) | (
+                await self.client.get_error_memory_values()
             )
-        except ClientError as error:
+        except SoftQLinkClientError as error:
             raise UpdateFailed(error) from error
         return self.datacache

--- a/custom_components/gruenbeck_softliQ_SC/entity.py
+++ b/custom_components/gruenbeck_softliQ_SC/entity.py
@@ -1,0 +1,30 @@
+"""Shared entity helpers for the Gruenbeck integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+from .coordinator import SoftQLinkDataUpdateCoordinator
+
+
+def get_entity_unique_id_prefix(coordinator: SoftQLinkDataUpdateCoordinator) -> str:
+    """Return the legacy entity unique ID prefix."""
+    return coordinator.config_entry.title.lower()
+
+
+def get_device_identifier(coordinator: SoftQLinkDataUpdateCoordinator) -> str:
+    """Return the legacy device identifier."""
+    return coordinator.config_entry.title
+
+
+def build_device_info(coordinator: SoftQLinkDataUpdateCoordinator) -> DeviceInfo:
+    """Build common device info for all entities."""
+    device_id = get_device_identifier(coordinator)
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_id)},
+        name=coordinator.config_entry.title,
+        manufacturer="Gruenbeck",
+        model=coordinator.client.model,
+        sw_version=coordinator.client.sw_version,
+    )

--- a/custom_components/gruenbeck_softliQ_SC/select.py
+++ b/custom_components/gruenbeck_softliQ_SC/select.py
@@ -1,19 +1,21 @@
+"""Select platform for Gruenbeck SoftliQ SC integration."""
+
+from __future__ import annotations
+
 from typing import Final
-from homeassistant.config_entries import ConfigEntry
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .const import DOMAIN
 from .coordinator import SoftQLinkDataUpdateCoordinator
-from .sensor import SoftQLinkSensor, SoftQLinkSensorEntityDescription
+from .entity import build_device_info, get_entity_unique_id_prefix
 
 
-class SoftQLinkSelectEntityDescription(
-    SoftQLinkSensorEntityDescription, SelectEntityDescription
-):
+class SoftQLinkSelectEntityDescription(SelectEntityDescription):
     """Base class for a Softliq select entity description."""
 
 
@@ -22,11 +24,9 @@ SELECT_DESCRIPTIONS: Final = [
         key="D_C_5_1",
         translation_key="D_C_5_1",
         entity_category=None,
-        device_class=SensorDeviceClass.ENUM,
-        options=["0", "1"],
+        options=["0", "1", "2", "3"],
     ),
 ]
-SELECT_DESCRIPTIONS_MAP = {desc.key: desc for desc in SELECT_DESCRIPTIONS}
 
 
 async def async_setup_entry(
@@ -42,8 +42,10 @@ async def async_setup_entry(
     async_add_entities(selects)
 
 
-class SoftQLinkSelectEntity(SoftQLinkSensor, SelectEntity):  # type: ignore
-    """Representation of a tplink select entity."""
+class SoftQLinkSelectEntity(
+    CoordinatorEntity[SoftQLinkDataUpdateCoordinator], SelectEntity
+):
+    """Representation of a SoftQLink select entity."""
 
     entity_description: SoftQLinkSelectEntityDescription
     _attr_has_entity_name = True
@@ -54,19 +56,29 @@ class SoftQLinkSelectEntity(SoftQLinkSensor, SelectEntity):  # type: ignore
         description: SoftQLinkSelectEntityDescription,
     ) -> None:
         """Initialize a select."""
-        super().__init__(coordinator, description)
-        self.entity_description = description  # type: ignore
-        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
+        super().__init__(coordinator)
+        self.entity_description = description
+        unique_id_prefix = get_entity_unique_id_prefix(coordinator)
+        self._attr_unique_id = f"{unique_id_prefix}-{description.key}".lower()
+        self._attr_device_info = build_device_info(coordinator)
+        self._handle_value_update()
 
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
-        await self.coordinator.clientMuxClient.setMode(option)
+        await self.coordinator.client.set_mode(option)
+        await self.coordinator.async_request_refresh()
 
     @callback
-    def _async_update_attrs(self) -> bool:
-        """Update the entity's attributes."""
-        if self.entity_description.key in self.coordinator.data:
-            self._attr_current_option = self.coordinator.data.get(
-                self.entity_description.key
-            )
-        return True
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._handle_value_update()
+        self.async_write_ha_state()
+
+    def _handle_value_update(self) -> None:
+        """Update the current selected option from coordinator data."""
+        current_option = self.coordinator.data.get(self.entity_description.key)
+        self._attr_current_option = (
+            current_option
+            if current_option in self.entity_description.options
+            else None
+        )

--- a/custom_components/gruenbeck_softliQ_SC/select.py
+++ b/custom_components/gruenbeck_softliQ_SC/select.py
@@ -3,8 +3,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.components.sensor import ( 
-    SensorDeviceClass, 
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
 )
 from .const import DOMAIN
 from .coordinator import SoftQLinkDataUpdateCoordinator
@@ -12,26 +12,21 @@ from .sensor import SoftQLinkSensor, SoftQLinkSensorEntityDescription
 
 
 class SoftQLinkSelectEntityDescription(
-    SoftQLinkSensorEntityDescription,
-    SelectEntityDescription
+    SoftQLinkSensorEntityDescription, SelectEntityDescription
 ):
     """Base class for a Softliq select entity description."""
+
 
 SELECT_DESCRIPTIONS: Final = [
     SoftQLinkSelectEntityDescription(
         key="D_C_5_1",
         translation_key="D_C_5_1",
         entity_category=None,
-        device_class= SensorDeviceClass.ENUM,
-        options=[
-            "0",
-            "1"
-        ],
+        device_class=SensorDeviceClass.ENUM,
+        options=["0", "1"],
     ),
-    
 ]
 SELECT_DESCRIPTIONS_MAP = {desc.key: desc for desc in SELECT_DESCRIPTIONS}
-
 
 
 async def async_setup_entry(
@@ -43,38 +38,35 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     selects = []
     for description in SELECT_DESCRIPTIONS:
-         selects.append(SoftQLinkSelectEntity(coordinator, description))
+        selects.append(SoftQLinkSelectEntity(coordinator, description))
     async_add_entities(selects)
 
 
-class SoftQLinkSelectEntity(SoftQLinkSensor,SelectEntity): # type: ignore
+class SoftQLinkSelectEntity(SoftQLinkSensor, SelectEntity):  # type: ignore
     """Representation of a tplink select entity."""
 
     entity_description: SoftQLinkSelectEntityDescription
     _attr_has_entity_name = True
-  
+
     def __init__(
-        self, 
-        coordinator: SoftQLinkDataUpdateCoordinator, 
-        description: SoftQLinkSelectEntityDescription, 
+        self,
+        coordinator: SoftQLinkDataUpdateCoordinator,
+        description: SoftQLinkSelectEntityDescription,
     ) -> None:
         """Initialize a select."""
-        super().__init__(
-            coordinator
-            ,description
-        )
-        self.entity_description = description # type: ignore
+        super().__init__(coordinator, description)
+        self.entity_description = description  # type: ignore
         self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
-   
-    
-     
+
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
-        await self.coordinator.clientMuxClient.setMode(option) 
+        await self.coordinator.clientMuxClient.setMode(option)
 
     @callback
     def _async_update_attrs(self) -> bool:
         """Update the entity's attributes."""
         if self.entity_description.key in self.coordinator.data:
-            self._attr_current_option = self.coordinator.data.get(self.entity_description.key) 
+            self._attr_current_option = self.coordinator.data.get(
+                self.entity_description.key
+            )
         return True

--- a/custom_components/gruenbeck_softliQ_SC/sensor.py
+++ b/custom_components/gruenbeck_softliQ_SC/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
 
 from homeassistant.components.sensor.const import SensorStateClass, SensorDeviceClass
 from homeassistant.components.sensor import (
@@ -21,14 +20,15 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import SoftQLinkDataUpdateCoordinator
+from .coordinator import SoftQLinkDataUpdateCoordinator
 from .const import DOMAIN, TOTAL_CONSUMPTION
-
-_LOGGER = logging.getLogger(__name__)
+from .entity import (
+    build_device_info,
+    get_entity_unique_id_prefix,
+)
 PARALLEL_UPDATES = 1
 
 
@@ -228,11 +228,8 @@ async def async_setup_entry(
     """Set up SoftQLink sensor entities based on a config entry."""
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    _LOGGER.info(coordinator.data)
     sensors = []
     for description in SENSOR_TYPES:
-        # When we use the nearest method, we are not sure which sensors are available
-        _LOGGER.info(description.key)
         sensors.append(SoftQLinkSensor(coordinator, description))
 
     async_add_entities(sensors, False)
@@ -248,27 +245,21 @@ class SoftQLinkSensor(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], SensorE
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{coordinator.name}")},
-            name=coordinator.name,
-            manufacturer="Gruenbeck",
-            model=coordinator.clientMuxClient.model,
-            sw_version=coordinator.clientMuxClient.sw_version,
-        )
-        self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
+        self.entity_description = description  # type: ignore[assignment]
+        self._attr_device_info = build_device_info(coordinator)
+        unique_id_prefix = get_entity_unique_id_prefix(coordinator)
+        self._attr_unique_id = f"{unique_id_prefix}-{description.key}".lower()
         self._attr_attribution = "Data from SoftQLink"
         self._attr_has_entity_name = True
-        if description.key in coordinator.data:
-            val = coordinator.data.get(description.key)
-            if val != "-":
-                self._attr_native_value = val
-        self.entity_description = description  # type: ignore
+        self._update_native_value()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.entity_description.key in self.coordinator.data:
-            val = self.coordinator.data.get(self.entity_description.key)
-            if val != "-":
-                self._attr_native_value = val
+        self._update_native_value()
         self.async_write_ha_state()
+
+    def _update_native_value(self) -> None:
+        """Update the current native value from coordinator data."""
+        val = self.coordinator.data.get(self.entity_description.key)
+        self._attr_native_value = None if val in (None, "-") else val

--- a/custom_components/gruenbeck_softliQ_SC/sensor.py
+++ b/custom_components/gruenbeck_softliQ_SC/sensor.py
@@ -1,17 +1,14 @@
 """Support for the SoftQLink sensor service."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
 
-from homeassistant.components.sensor.const import (
-    SensorStateClass,
-    SensorDeviceClass
-)
+from homeassistant.components.sensor.const import SensorStateClass, SensorDeviceClass
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
-   
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -21,7 +18,7 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolume,
     UnitOfVolumeFlowRate,
-    UnitOfElectricCurrent
+    UnitOfElectricCurrent,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -38,7 +35,6 @@ PARALLEL_UPDATES = 1
 @dataclass(frozen=True)
 class SoftQLinkSensorEntityDescription(SensorEntityDescription):
     """Class describing SoftQLink sensor entities."""
-
 
 
 SENSOR_TYPES: tuple[SoftQLinkSensorEntityDescription, ...] = (
@@ -80,7 +76,7 @@ SENSOR_TYPES: tuple[SoftQLinkSensorEntityDescription, ...] = (
         key="D_A_1_7",
         translation_key="D_A_1_7",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
-        state_class=SensorStateClass.MEASUREMENT,  
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -242,7 +238,7 @@ async def async_setup_entry(
     async_add_entities(sensors, False)
 
 
-class SoftQLinkSensor(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], SensorEntity): # type: ignore
+class SoftQLinkSensor(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], SensorEntity):  # type: ignore
     """Define an SoftQLink sensor."""
 
     def __init__(
@@ -257,16 +253,16 @@ class SoftQLinkSensor(CoordinatorEntity[SoftQLinkDataUpdateCoordinator], SensorE
             name=coordinator.name,
             manufacturer="Gruenbeck",
             model=coordinator.clientMuxClient.model,
-            sw_version=coordinator.clientMuxClient.sw_version
+            sw_version=coordinator.clientMuxClient.sw_version,
         )
         self._attr_unique_id = f"{coordinator.name}-{description.key}".lower()
         self._attr_attribution = "Data from SoftQLink"
-        self._attr_has_entity_name = True 
+        self._attr_has_entity_name = True
         if description.key in coordinator.data:
             val = coordinator.data.get(description.key)
             if val != "-":
                 self._attr_native_value = val
-        self.entity_description = description # type: ignore
+        self.entity_description = description  # type: ignore
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
+++ b/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
@@ -93,6 +93,7 @@ class SoftQLinkMuxClient:
                 "D_Y_5",
                 "D_Y_6",
                 "D_D_1",
+                "D_B_1",
             ]
         )
 
@@ -112,37 +113,21 @@ class SoftQLinkMuxClient:
                     data=query,
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 ) as response:
-                    await response.text()
+                    response = await response.text()
+                    _LOGGER.info("Gruenbeck: Manual regeneration: %s", response )
             except ServerDisconnectedError:
+                _LOGGER.warning("Gruenbeck: manual regeneration failed (device disconnected)")
                 pass  # Device closes connection after accepting command
             except Exception as e:
-                _LOGGER.error("Manual regeneration failed: %s", e)
+                _LOGGER.error("Gruenbeck: Manual regeneration failed: %s", e)
                 raise
-
-    async def resetErrorMemory(self) -> None:
-        """Reset the error memory."""
-        async with self._lock:
-            query = "id=0000&edit=D_M_3_3>1&code=189&show=D_M_3_3~"
-            url = f"http://{self.host}/mux_http"
-            try:
-                async with self.session.post(
-                    url,
-                    timeout=ClientTimeout(5000),
-                    data=query,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                ) as response:
-                    await response.text()
-            except ServerDisconnectedError:
-                pass  # Device closes connection after accepting command
-            except Exception as e:
-                _LOGGER.error("Error memory reset failed: %s", e)
-                raise
+ 
 
     async def resetErrorMemory(self) -> None:
         """Reset the error memory (Mux code 189)."""
         async with self._lock:
             _LOGGER.warning("Gruenbeck: resetErrorMemory called")
-            query = "id=0000&code=189&show=~"
+            query = "id=0000&edit=D_M_3_3>1&code=189&show=D_M_3_3~"
             url = f"http://{self.host}/mux_http"
             try:
                 async with self.session.post(

--- a/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
+++ b/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
@@ -1,4 +1,5 @@
 """MUX interface of Gruenbeck SoftQLink Water Softener."""
+
 import asyncio
 import logging
 
@@ -64,7 +65,16 @@ class SoftQLinkMuxClient:
         """Get some basic meter values e.g. D_K_?."""
         lastErrorCode = "D_K_10_1"
         result = await self._executeMuxQuery(
-            props=["D_K_3", "D_K_2", "D_K_5",  "D_K_8", "D_K_9", "D_Y_10_1", lastErrorCode], code="245"
+            props=[
+                "D_K_3",
+                "D_K_2",
+                "D_K_5",
+                "D_K_8",
+                "D_K_9",
+                "D_Y_10_1",
+                lastErrorCode,
+            ],
+            code="245",
         )
         if lastErrorCode in result:
             errorcode = result[lastErrorCode]
@@ -99,7 +109,7 @@ class SoftQLinkMuxClient:
 
     async def setMode(self, mode):
         """Set a parameter"""
-        return await self._executeMuxQuery([],"","D_C_5_1", mode)
+        return await self._executeMuxQuery([], "", "D_C_5_1", mode)
 
     async def startManualRegeneration(self) -> None:
         """Trigger a manual regeneration cycle."""
@@ -114,14 +124,15 @@ class SoftQLinkMuxClient:
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 ) as response:
                     response = await response.text()
-                    _LOGGER.info("Gruenbeck: Manual regeneration: %s", response )
+                    _LOGGER.info("Gruenbeck: Manual regeneration: %s", response)
             except ServerDisconnectedError:
-                _LOGGER.warning("Gruenbeck: manual regeneration failed (device disconnected)")
+                _LOGGER.warning(
+                    "Gruenbeck: manual regeneration failed (device disconnected)"
+                )
                 pass  # Device closes connection after accepting command
             except Exception as e:
                 _LOGGER.error("Gruenbeck: Manual regeneration failed: %s", e)
                 raise
- 
 
     async def resetErrorMemory(self) -> None:
         """Reset the error memory (Mux code 189)."""
@@ -139,7 +150,8 @@ class SoftQLinkMuxClient:
                     body = await response.text()
                     _LOGGER.info(
                         "Gruenbeck: error memory reset response (HTTP %s): %s",
-                        response.status, body,
+                        response.status,
+                        body,
                     )
             except ServerDisconnectedError:
                 _LOGGER.warning("Gruenbeck: error reset sent (device disconnected)")
@@ -148,7 +160,7 @@ class SoftQLinkMuxClient:
                 raise
 
     async def _executeMuxQuery(
-        self, props: list[str], code: str = "", editProp:str="", editValue:str=""
+        self, props: list[str], code: str = "", editProp: str = "", editValue: str = ""
     ) -> dict[str, str]:
         async with self._lock:
             retry = 0
@@ -175,12 +187,17 @@ class SoftQLinkMuxClient:
                             else:
                                 _LOGGER.debug(
                                     "Empty result for '%s' on '%s' %s-times",
-                                    query, url, retry,
+                                    query,
+                                    url,
+                                    retry,
                                 )
                 except Exception as e:
                     _LOGGER.debug(
                         "Failed to execute '%s' on '%s' %s-times Error: '%s'",
-                        query, url, retry, e,
+                        query,
+                        url,
+                        retry,
+                        e,
                     )
                     if retry < maxRetry:
                         continue
@@ -190,8 +207,7 @@ class SoftQLinkMuxClient:
                 raise Exception("Mux server did not return a valid content")
             return result
 
-
-    def __generateQuery(self, props, editProp, editValue ,code):
+    def __generateQuery(self, props, editProp, editValue, code):
         clientId = f"id={self.clientId}"
         show = f"&show={'|'.join(props)}"
         edit = ""
@@ -201,7 +217,7 @@ class SoftQLinkMuxClient:
             edit = f"&edit={editProp}>{editValue}"
         query = f"{clientId}{code}{edit}{show}~"
         return query
-    
+
     def __calculate_total__(self, flow, data_dict):
         if self.lastFlow:
             now = dt_util.utcnow()
@@ -213,7 +229,7 @@ class SoftQLinkMuxClient:
 
     def __parse_xml_to_dict(self, xml_data):
         root = defET.fromstring(xml_data)
-        data_dict = {} 
+        data_dict = {}
         for elem in root:
             if elem.tag != "code":
                 data_dict[elem.tag] = (elem.text or "").strip()

--- a/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
+++ b/custom_components/gruenbeck_softliQ_SC/softQLinkMuxClient.py
@@ -2,22 +2,43 @@
 
 import asyncio
 import logging
-
-from aiohttp import ClientSession, ClientTimeout, ServerDisconnectedError
-import defusedxml.ElementTree as defET
 from decimal import Decimal
-import homeassistant.util.dt as dt_util
+from typing import TypeAlias
 
-from .const import TOTAL_CONSUMPTION
+from aiohttp import ClientError, ClientSession, ClientTimeout, ServerDisconnectedError
+import defusedxml.ElementTree as defET
+import homeassistant.util.dt as dt_util
+from xml.etree.ElementTree import ParseError
+
+from .const import REQUEST_TIMEOUT, TOTAL_CONSUMPTION
 
 _LOGGER = logging.getLogger(__name__)
+SoftQLinkValue: TypeAlias = str | Decimal
+
+
+class SoftQLinkClientError(Exception):
+    """Base exception for SoftQLink client failures."""
+
+
+class SoftQLinkTimeoutError(SoftQLinkClientError):
+    """The device did not answer within the request timeout."""
+
+
+class SoftQLinkResponseError(SoftQLinkClientError):
+    """The device returned an invalid response."""
+
+
+class SoftQLinkParseError(SoftQLinkClientError):
+    """The device returned malformed XML."""
 
 
 class SoftQLinkMuxClient:
     """Encapsulates the http communication to the SoftQLink."""
 
+    _timeout = ClientTimeout(total=REQUEST_TIMEOUT)
+
     @staticmethod
-    async def create(host: str, session: ClientSession):
+    async def create(host: str, session: ClientSession) -> "SoftQLinkMuxClient":
         """Create generates a client and initialize the connection."""
         client = SoftQLinkMuxClient(host, session)
         await client._init()
@@ -27,25 +48,28 @@ class SoftQLinkMuxClient:
         """Initialize."""
         self.session = session
         self.host = host
-        self.clientId = 2444
+        self.client_id = 2444
         self.connected = False
-        self.total_consumption = 0
-        self.lastFlow = 0
+        self.total_consumption: Decimal = Decimal("0")
+        self.last_flow = ""
         self.last_update = dt_util.utcnow()
         self._lock = asyncio.Lock()
+        self.sw_version = ""
+        self.model = ""
 
     async def _init(self):
         """Initialize Software Version and Model from the SoftQLink Device."""
-        self.sw_version = await self.__getSoftwareVersion()
-        self.model = await self.__getSoftenerType()
+        self.sw_version = await self._get_software_version()
+        self.model = await self._get_softener_type()
         if self.model:
             self.connected = True
 
-    async def __getSoftenerType(self) -> str:
+    async def _get_softener_type(self) -> str:
         typecode = "D_F_4"
-        result = await self._executeMuxQuery(props=[typecode], code="290")
-        if typecode in result:
-            match result[typecode]:
+        result = await self._execute_mux_query(props=[typecode], code="290")
+        type_value = result.get(typecode)
+        if isinstance(type_value, str):
+            match type_value:
                 case "1":
                     return "softliQ:SC18"
                 case "2":
@@ -54,39 +78,34 @@ class SoftQLinkMuxClient:
                     return "Unknown Device"
         return ""
 
-    async def __getSoftwareVersion(self) -> str:
-        softwareCode = "D_Y_6"
-        result = await self._executeMuxQuery(props=[softwareCode])
-        if softwareCode in result:
-            return result[softwareCode]
+    async def _get_software_version(self) -> str:
+        software_code = "D_Y_6"
+        result = await self._execute_mux_query(props=[software_code])
+        software_value = result.get(software_code)
+        if isinstance(software_value, str):
+            return software_value
         return ""
 
-    async def getMeterValues(self) -> dict[str, str]:
-        """Get some basic meter values e.g. D_K_?."""
-        lastErrorCode = "D_K_10_1"
-        result = await self._executeMuxQuery(
+    async def get_error_memory_values(self) -> dict[str, SoftQLinkValue]:
+        """Get error-memory-related values from mux code 245."""
+        last_error_code = "D_K_10_1"
+        result = await self._execute_mux_query(
             props=[
                 "D_K_3",
                 "D_K_2",
                 "D_K_5",
                 "D_K_8",
                 "D_K_9",
-                "D_Y_10_1",
-                lastErrorCode,
+                last_error_code,
             ],
             code="245",
         )
-        if lastErrorCode in result:
-            errorcode = result[lastErrorCode]
-            if errorcode.find("_") > -1:
-                codeAndDay = errorcode.split("_")
-                result[lastErrorCode] = codeAndDay[0]
-                result[f"{lastErrorCode}_Hours"] = codeAndDay[1].replace("h", "")
+        self._split_error_code_and_age(result, last_error_code)
         return result
 
-    async def getCurrentValues(self) -> dict[str, str]:
+    async def get_current_values(self) -> dict[str, SoftQLinkValue]:
         """Get current values e.g D_A_?, D_Y_? and D_D_?."""
-        return await self._executeMuxQuery(
+        return await self._execute_mux_query(
             props=[
                 "D_A_1_1",
                 "D_A_1_2",
@@ -102,138 +121,174 @@ class SoftQLinkMuxClient:
                 "D_Y_3",
                 "D_Y_5",
                 "D_Y_6",
+                "D_Y_10_1",
                 "D_D_1",
                 "D_B_1",
             ]
         )
 
-    async def setMode(self, mode):
-        """Set a parameter"""
-        return await self._executeMuxQuery([], "", "D_C_5_1", mode)
+    async def set_mode(self, mode: str) -> dict[str, SoftQLinkValue]:
+        """Set the device mode."""
+        return await self._execute_mux_query(
+            [],
+            edit_prop="D_C_5_1",
+            edit_value=mode,
+            edit_result = mode
+        )
 
-    async def startManualRegeneration(self) -> None:
+    async def start_manual_regeneration(self) -> None:
         """Trigger a manual regeneration cycle."""
-        async with self._lock:
-            query = "id=0000&edit=D_B_1>1&show=D_B_1~"
-            url = f"http://{self.host}/mux_http"
-            try:
-                async with self.session.post(
-                    url,
-                    timeout=ClientTimeout(5000),
-                    data=query,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                ) as response:
-                    response = await response.text()
-                    _LOGGER.info("Gruenbeck: Manual regeneration: %s", response)
-            except ServerDisconnectedError:
-                _LOGGER.warning(
-                    "Gruenbeck: manual regeneration failed (device disconnected)"
-                )
-                pass  # Device closes connection after accepting command
-            except Exception as e:
-                _LOGGER.error("Gruenbeck: Manual regeneration failed: %s", e)
-                raise
+        await self._execute_mux_query(
+            ["D_B_1"],
+            edit_prop="D_B_1",
+            edit_value="1",
+            edit_result = "1"
+        )
 
-    async def resetErrorMemory(self) -> None:
+    async def reset_error_memory(self) -> None:
         """Reset the error memory (Mux code 189)."""
-        async with self._lock:
-            _LOGGER.warning("Gruenbeck: resetErrorMemory called")
-            query = "id=0000&edit=D_M_3_3>1&code=189&show=D_M_3_3~"
-            url = f"http://{self.host}/mux_http"
-            try:
-                async with self.session.post(
-                    url,
-                    timeout=ClientTimeout(5000),
-                    data=query,
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                ) as response:
-                    body = await response.text()
-                    _LOGGER.info(
-                        "Gruenbeck: error memory reset response (HTTP %s): %s",
-                        response.status,
-                        body,
-                    )
-            except ServerDisconnectedError:
-                _LOGGER.warning("Gruenbeck: error reset sent (device disconnected)")
-            except Exception as e:
-                _LOGGER.error("Gruenbeck: error reset failed: %s", e)
-                raise
+        await self._execute_mux_query(
+            ["D_M_3_3"],
+            code="189",
+            edit_prop="D_M_3_3",
+            edit_value="1",
+            edit_result = "0"
+        )
+   
 
-    async def _executeMuxQuery(
-        self, props: list[str], code: str = "", editProp: str = "", editValue: str = ""
-    ) -> dict[str, str]:
+    async def _execute_mux_query(
+        self,
+        props: list[str],
+        code: str = "",
+        edit_prop: str = "",
+        edit_value: str = "",
+        edit_result: str = ""
+    ) -> dict[str, SoftQLinkValue]:
+        """Execute a mux query and parse the XML response."""
+        query = self._generate_query(props, edit_prop, edit_value, code)
+        xml = await self._post_query(query, expect_xml=True)
+        result = self._parse_xml_to_dict(xml)
+        if edit_result:
+            self._validate_expected_value(result, edit_prop, edit_result)
+        return result
+
+    async def _post_query(
+        self,
+        query: str,
+        *,
+        expect_xml: bool,
+    ) -> str:
+        """POST a query to the device and return the raw body."""
         async with self._lock:
-            retry = 0
-            maxRetry = 5
-            success = False
-            query = self.__generateQuery(props, editProp, editValue, code)
             url = f"http://{self.host}/mux_http"
-            result: dict[str, str] = {}
-            while not success and retry < maxRetry:
-                retry += 1
+            max_retry = 5
+            for retry in range(1, max_retry + 1):
                 try:
                     async with self.session.post(
                         url,
-                        timeout=ClientTimeout(5000),
+                        timeout=self._timeout,
                         data=query,
                         headers={"Content-Type": "application/x-www-form-urlencoded"},
                     ) as response:
-                        if response.status == 200:
-                            await asyncio.sleep(0.001)
-                            xml = await response.text()
-                            if xml:
-                                result = self.__parse_xml_to_dict(xml)
-                                success = True
-                            else:
-                                _LOGGER.debug(
-                                    "Empty result for '%s' on '%s' %s-times",
-                                    query,
-                                    url,
-                                    retry,
-                                )
-                except Exception as e:
-                    _LOGGER.debug(
-                        "Failed to execute '%s' on '%s' %s-times Error: '%s'",
-                        query,
-                        url,
-                        retry,
-                        e,
+                        body = await response.text()
+                        if response.status != 200:
+                            raise SoftQLinkResponseError(
+                                f"Unexpected HTTP status {response.status}"
+                            )
+                        if expect_xml and not body:
+                            raise SoftQLinkResponseError(
+                                "Mux server returned an empty payload"
+                            )
+                        return body
+                except ServerDisconnectedError:
+                    last_error = SoftQLinkResponseError(
+                        "Device disconnected unexpectedly"
                     )
-                    if retry < maxRetry:
-                        continue
-                    else:
-                        raise
-            if not success:
-                raise Exception("Mux server did not return a valid content")
-            return result
+                except TimeoutError:
+                    last_error = SoftQLinkTimeoutError("Request to SoftQLink timed out")
+                except ClientError as err:
+                    last_error = SoftQLinkResponseError(str(err))
+                except SoftQLinkClientError as err:
+                    last_error = err
+                _LOGGER.debug(
+                    "Failed to execute '%s' on '%s' %s times: %s",
+                    query,
+                    url,
+                    retry,
+                    last_error,
+                )
+                if retry == max_retry:
+                    raise last_error
+            raise SoftQLinkResponseError("Mux server did not return a valid response")
 
-    def __generateQuery(self, props, editProp, editValue, code):
-        clientId = f"id={self.clientId}"
-        show = f"&show={'|'.join(props)}"
+    def _generate_query(
+        self,
+        props: list[str],
+        edit_prop: str,
+        edit_value: str,
+        code: str,
+    ) -> str:
+        show_props = list(props)
+        if edit_prop and edit_prop not in show_props:
+            show_props.append(edit_prop)
+
+        clientId = f"id={self.client_id}"
+        show = f"&show={'|'.join(show_props)}"
         edit = ""
         if code:
             code = f"&code={code}"
-        if editProp:
-            edit = f"&edit={editProp}>{editValue}"
+        if edit_prop:
+            edit = f"&edit={edit_prop}>{edit_value}"
         query = f"{clientId}{code}{edit}{show}~"
         return query
 
-    def __calculate_total__(self, flow, data_dict):
-        if self.lastFlow:
+    def _calculate_total(self, flow: str) -> None:
+        if self.last_flow:
             now = dt_util.utcnow()
             elapsed_time = (now - self.last_update).total_seconds()
             area = Decimal(flow) * Decimal(elapsed_time)
             self.total_consumption += area / (60 * 60)
-        self.lastFlow = flow
+        self.last_flow = flow
         self.last_update = dt_util.utcnow()
 
-    def __parse_xml_to_dict(self, xml_data):
-        root = defET.fromstring(xml_data)
-        data_dict = {}
+    def _parse_xml_to_dict(self, xml_data: str) -> dict[str, SoftQLinkValue]:
+        try:
+            root = defET.fromstring(xml_data)
+        except ParseError as err:
+            raise SoftQLinkParseError("Mux server returned malformed XML") from err
+
+        data_dict: dict[str, SoftQLinkValue] = {}
         for elem in root:
             if elem.tag != "code":
                 data_dict[elem.tag] = (elem.text or "").strip()
                 if elem.tag == "D_A_1_1":
-                    self.__calculate_total__(data_dict[elem.tag], data_dict)
+                    self._calculate_total(str(data_dict[elem.tag]))
         data_dict[TOTAL_CONSUMPTION] = round(self.total_consumption, 4)
         return data_dict
+
+    def _validate_expected_value(
+        self,
+        data: dict[str, SoftQLinkValue],
+        prop: str,
+        expected_value: str,
+    ) -> None:
+        """Validate that the device echoed the expected value."""
+        actual_value = data.get(prop)
+        if actual_value != expected_value:
+            raise SoftQLinkResponseError(
+                f"Expected {prop}={expected_value}, got {actual_value!r}"
+            )
+
+    def _split_error_code_and_age(
+        self,
+        data: dict[str, SoftQLinkValue],
+        error_code_key: str,
+    ) -> None:
+        """Split a combined error code like ``E4_12h`` into code and age fields."""
+        error_code = data.get(error_code_key)
+        if not isinstance(error_code, str) or "_" not in error_code:
+            return
+
+        code_and_age = error_code.split("_", maxsplit=1)
+        data[error_code_key] = code_and_age[0]
+        data[f"{error_code_key}_Hours"] = code_and_age[1].replace("h", "")

--- a/custom_components/gruenbeck_softliQ_SC/strings.json
+++ b/custom_components/gruenbeck_softliQ_SC/strings.json
@@ -88,6 +88,7 @@
       "D_K_10_1": {
         "name": "Last Error",
         "state": {
+          "0": "No Error",
           "E1": "Malfunction in the drive control valve regeneration",
           "E4": "Fill salt tablets in the salt tank",
           "E6": "Water meter regeneration quantity not reached",

--- a/custom_components/gruenbeck_softliQ_SC/strings.json
+++ b/custom_components/gruenbeck_softliQ_SC/strings.json
@@ -103,6 +103,11 @@
         "name": "Raw water hardness"
       }
     },
+    "binary_sensor": {
+      "regeneration_running": {
+        "name": "Regeneration running"
+      }
+    },
     "select": {
       "D_C_5_1": {
         "name": "Mode",

--- a/custom_components/gruenbeck_softliQ_SC/translations/de.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/de.json
@@ -108,6 +108,11 @@
                 "name": "Rohwasserhärte"
             }
         },
+        "binary_sensor": {
+            "regeneration_running": {
+                "name": "Regeneration aktiv"
+            }
+        },
         "select":{
             "D_C_5_1": {
                 "name": "Modus",

--- a/custom_components/gruenbeck_softliQ_SC/translations/de.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/de.json
@@ -93,10 +93,11 @@
             "D_K_10_1": {
                 "name": "Letzter Fehler",
                 "state": {
+                    "0": "Kein Fehler",
                     "E1": "Fehlfunktion im Antriebsregelventil der Regeneration",
                     "E4": "Salztabletten im Salztank nachfüllen",
                     "E6": "Regenerationsmenge des Wassermessers nicht erreicht",
-                    "E7": "Das System saugt Brine im Salztank zu schlecht ab",
+                    "E7": "Das System saugt Sole im Salztank zu schlecht ab",
                     "EA": "Warnung bei niedrigem Salzgehalt",
                     "EC": "Nennfluss überschritten"
                 }

--- a/custom_components/gruenbeck_softliQ_SC/translations/en.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/en.json
@@ -93,6 +93,7 @@
       "D_K_10_1": {
         "name": "Last Error",
         "state": {
+          "0": "No Error",
           "E1": "Malfunction in the drive control valve regeneration",
           "E4": "Fill salt tablets in the salt tank",
           "E6": "Water meter regeneration quantity not reached",

--- a/custom_components/gruenbeck_softliQ_SC/translations/en.json
+++ b/custom_components/gruenbeck_softliQ_SC/translations/en.json
@@ -108,6 +108,11 @@
         "name": "Raw water hardness"
       }
     },
+    "binary_sensor": {
+      "regeneration_running": {
+        "name": "Regeneration running"
+      }
+    },
     "select": {
       "D_C_5_1": {
         "name": "Mode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [tool.pyright]
 pythonVersion = "3.13"
+typeCheckingMode = "basic"
+venvPath = "."
+venv = ".venv"
+exclude = [".venv"]
+reportIncompatibleMethodOverride = "none"
+reportIncompatibleVariableOverride = "none"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-colorlog==6.7.0
-homeassistant==2025.8.2
-pip>=24.2
-ruff==0.5.3
-aiohttp==3.12.15
+colorlog==6.10.1
+homeassistant==2026.2.3
+pip>=26.0.1
+pre-commit==4.3.0
+ruff==0.15.8
+aiohttp==3.13.3
 aiohttp-cors==0.8.1
-aiohttp-zlib-ng==0.3.1
+aiohttp-zlib-ng==0.3.2

--- a/tests/test_gruenbeck.py
+++ b/tests/test_gruenbeck.py
@@ -1,0 +1,505 @@
+"""Tests for the Gruenbeck SoftliQ integration."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+from aiohttp import ClientSession, ServerDisconnectedError
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.gruenbeck_softliQ_SC.button import (
+    SoftQLinkButtonEntity,
+    SoftQLinkButtonEntityDescription,
+)
+from custom_components.gruenbeck_softliQ_SC.config_flow import GruenBeckConfigFlow
+from custom_components.gruenbeck_softliQ_SC.coordinator import (
+    SoftQLinkDataUpdateCoordinator,
+)
+from custom_components.gruenbeck_softliQ_SC.select import (
+    SELECT_DESCRIPTIONS,
+    SoftQLinkSelectEntity,
+)
+from custom_components.gruenbeck_softliQ_SC.softQLinkMuxClient import (
+    SoftQLinkMuxClient,
+    SoftQLinkParseError,
+    SoftQLinkResponseError,
+)
+
+
+def make_hass() -> HomeAssistant:
+    """Build a typed Home Assistant test double."""
+    return cast(HomeAssistant, SimpleNamespace(loop=asyncio.get_running_loop()))
+
+
+def make_config_entry(title: str, host: str) -> ConfigEntry[Any]:
+    """Build a typed config-entry test double."""
+    return cast(
+        ConfigEntry[Any],
+        SimpleNamespace(
+            title=title,
+            data={CONF_HOST: host},
+            async_on_unload=lambda _: None,
+        ),
+    )
+
+
+def make_client_double(**kwargs: Any) -> SoftQLinkMuxClient:
+    """Build a typed client test double."""
+    return cast(SoftQLinkMuxClient, SimpleNamespace(**kwargs))
+
+
+def make_coordinator_double(**kwargs: Any) -> SoftQLinkDataUpdateCoordinator:
+    """Build a typed coordinator test double."""
+    return cast(SoftQLinkDataUpdateCoordinator, SimpleNamespace(**kwargs))
+
+
+class MockResponse:
+    """Minimal aiohttp response mock."""
+
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        self._body = body
+
+    async def text(self) -> str:
+        """Return the mocked response text."""
+        return self._body
+
+    async def __aenter__(self) -> "MockResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class SoftQLinkClientTests(unittest.IsolatedAsyncioTestCase):
+    """Tests covering client transport behavior."""
+
+    async def test_execute_mux_query_parses_successful_xml(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.return_value = MockResponse(
+            200,
+            "<root><D_Y_6>1.0</D_Y_6></root>",
+        )
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        result = await client._execute_mux_query(["D_Y_6"])
+
+        self.assertEqual(result["D_Y_6"], "1.0")
+
+    async def test_execute_mux_query_rejects_empty_payload(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.return_value = MockResponse(200, "")
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        with self.assertRaises(SoftQLinkResponseError):
+            await client._execute_mux_query(["D_Y_6"])
+
+    async def test_execute_mux_query_rejects_non_200_response(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.return_value = MockResponse(503, "error")
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        with self.assertRaises(SoftQLinkResponseError):
+            await client._execute_mux_query(["D_Y_6"])
+
+    async def test_execute_mux_query_rejects_invalid_xml(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.return_value = MockResponse(200, "<root>")
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        with self.assertRaises(SoftQLinkParseError):
+            await client._execute_mux_query(["D_Y_6"])
+
+    async def test_execute_mux_query_rejects_unconfirmed_edit_value(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.return_value = MockResponse(
+            200,
+            "<root><D_C_5_1>0</D_C_5_1></root>",
+        )
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        with self.assertRaises(SoftQLinkResponseError):
+            await client._execute_mux_query(
+                [],
+                edit_prop="D_C_5_1",
+                edit_value="1",
+                edit_result="1",
+            )
+
+    async def test_manual_regeneration_rejects_disconnect(self) -> None:
+        session = AsyncMock(spec=ClientSession)
+        session.post.side_effect = ServerDisconnectedError()
+        client = SoftQLinkMuxClient("waterbox", session)
+
+        with self.assertRaises(SoftQLinkResponseError):
+            await client.start_manual_regeneration()
+
+
+class SoftQLinkCoordinatorTests(unittest.IsolatedAsyncioTestCase):
+    """Tests covering coordinator behavior."""
+
+    async def test_coordinator_wraps_client_errors(self) -> None:
+        client = make_client_double(
+            get_current_values=AsyncMock(side_effect=SoftQLinkResponseError("bad")),
+            get_error_memory_values=AsyncMock(),
+        )
+        entry = make_config_entry("Softener", "waterbox")
+        hass = make_hass()
+        coordinator = SoftQLinkDataUpdateCoordinator(hass, entry, client)
+
+        with self.assertRaises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    async def test_set_active_button_action_updates_state_and_notifies(self) -> None:
+        client = make_client_double(
+            get_current_values=AsyncMock(return_value={}),
+            get_error_memory_values=AsyncMock(return_value={}),
+        )
+        entry = make_config_entry("Softener", "waterbox")
+        hass = make_hass()
+        coordinator = SoftQLinkDataUpdateCoordinator(hass, entry, client)
+        coordinator.async_update_listeners = Mock()
+
+        coordinator.set_active_button_action("manual_regeneration")
+
+        self.assertTrue(coordinator.button_action_in_progress)
+        self.assertEqual(coordinator.active_button_key, "manual_regeneration")
+        coordinator.async_update_listeners.assert_called_once()
+
+        coordinator.async_update_listeners.reset_mock()
+
+        coordinator.set_active_button_action(None)
+
+        self.assertFalse(coordinator.button_action_in_progress)
+        self.assertIsNone(coordinator.active_button_key)
+        coordinator.async_update_listeners.assert_called_once()
+
+
+class SoftQLinkConfigFlowTests(unittest.IsolatedAsyncioTestCase):
+    """Tests covering config-flow behavior."""
+
+    async def test_migrate_old_entry_recreates_entry_from_legacy_domain(self) -> None:
+        flow = GruenBeckConfigFlow()
+        async_remove = AsyncMock()
+        async_add = AsyncMock()
+        flow.hass = cast(
+            HomeAssistant,
+            SimpleNamespace(
+                config_entries=SimpleNamespace(
+                    async_remove=async_remove,
+                    async_add=async_add,
+                ),
+            ),
+        )
+        flow.flow_id = "test-flow-id"
+
+        old_entry = SimpleNamespace(
+            entry_id="legacy-entry-id",
+            title="Legacy Softener",
+            version=1,
+            data={
+                CONF_HOST: "WaterBox.local",
+                CONF_NAME: "Friendly Name",
+            },
+            options={"opt": "value"},
+            source="user",
+            unique_id=None,
+            discovery_keys={},
+            minor_version=0,
+        )
+
+        result = await flow._async_migrate_old_entry(old_entry)
+
+        async_remove.assert_awaited_once_with("legacy-entry-id")
+        async_add.assert_awaited_once()
+
+        migrated_entry = async_add.await_args.args[0]
+        self.assertEqual(migrated_entry.entry_id, "legacy-entry-id")
+        self.assertEqual(migrated_entry.domain, "gruenbeck_softliq_sc")
+        self.assertEqual(migrated_entry.unique_id, "waterbox.local")
+        self.assertEqual(migrated_entry.data[CONF_HOST], "WaterBox.local")
+        self.assertEqual(
+            result["type"],
+            FlowResultType.SHOW_PROGRESS_DONE,
+        )
+
+
+class SoftQLinkEntityTests(unittest.IsolatedAsyncioTestCase):
+    """Tests covering entity state updates and identifiers."""
+
+    async def test_select_refreshes_and_tracks_option(self) -> None:
+        set_mode = AsyncMock()
+        request_refresh = AsyncMock()
+        coordinator = make_coordinator_double(
+            data={"D_C_5_1": "2"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(
+                model="softliQ:SC18",
+                sw_version="1.0",
+                set_mode=set_mode,
+            ),
+            async_request_refresh=request_refresh,
+        )
+        entity = SoftQLinkSelectEntity(coordinator, SELECT_DESCRIPTIONS[0])
+
+        self.assertEqual(entity.current_option, "2")
+
+        await entity.async_select_option("1")
+
+        set_mode.assert_awaited_once_with("1")
+        request_refresh.assert_awaited_once()
+
+    async def test_button_and_select_keep_legacy_unique_ids(self) -> None:
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "0", "D_C_5_1": "0"},
+            config_entry=make_config_entry("Friendly Name", "WaterBox"),
+            client=make_client_double(model="softliQ:SC18", sw_version="1.0"),
+            async_request_refresh=AsyncMock(),
+            button_action_in_progress=False,
+            active_button_key=None,
+            last_update_success=True,
+        )
+
+        button = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="manual_regeneration",
+                    translation_key="manual_regeneration",
+                ),
+            ),
+        )
+        select = SoftQLinkSelectEntity(coordinator, SELECT_DESCRIPTIONS[0])
+
+        self.assertEqual(button.unique_id, "friendly name-manual_regeneration")
+        self.assertEqual(select.unique_id, "friendly name-d_c_5_1")
+        device_info = cast(dict[str, object], button.device_info)
+        identifiers = cast(set[tuple[str, str]], device_info["identifiers"])
+        self.assertEqual(
+            next(iter(identifiers)),
+            ("gruenbeck_softliq_sc", "Friendly Name"),
+        )
+
+    async def test_button_press_sets_busy_state_and_clears_it_after_refresh(self) -> None:
+        start_manual_regeneration = AsyncMock()
+        update_listeners = Mock()
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "0"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(
+                model="softliQ:SC18",
+                sw_version="1.0",
+                start_manual_regeneration=start_manual_regeneration,
+            ),
+            async_request_refresh=AsyncMock(),
+            button_action_in_progress=False,
+            active_button_key=None,
+            last_update_success=True,
+            async_update_listeners=update_listeners,
+        )
+
+        def set_active_button_action(button_key: str | None) -> None:
+            coordinator.button_action_in_progress = button_key is not None
+            coordinator.active_button_key = button_key
+            coordinator.async_update_listeners()
+
+        coordinator.set_active_button_action = set_active_button_action
+        entity = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="manual_regeneration",
+                    translation_key="manual_regeneration",
+                ),
+            ),
+        )
+        other_button = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="reset_error_memory",
+                    translation_key="reset_error_memory",
+                ),
+            ),
+        )
+
+        refresh_started = asyncio.Event()
+        allow_refresh_to_finish = asyncio.Event()
+
+        async def blocking_refresh() -> None:
+            refresh_started.set()
+            await allow_refresh_to_finish.wait()
+
+        coordinator.async_request_refresh.side_effect = blocking_refresh
+
+        press_task = asyncio.create_task(entity.async_press())
+        await refresh_started.wait()
+
+        self.assertTrue(coordinator.button_action_in_progress)
+        self.assertFalse(entity.available)
+        self.assertFalse(other_button.available)
+        start_manual_regeneration.assert_awaited_once()
+
+        allow_refresh_to_finish.set()
+        await press_task
+
+        self.assertFalse(coordinator.button_action_in_progress)
+        self.assertIsNone(coordinator.active_button_key)
+        self.assertTrue(entity.available)
+        self.assertTrue(other_button.available)
+        self.assertEqual(update_listeners.call_count, 2)
+
+    async def test_button_press_clears_busy_state_after_failure(self) -> None:
+        reset_error_memory = AsyncMock(side_effect=RuntimeError("boom"))
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "0"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(
+                model="softliQ:SC18",
+                sw_version="1.0",
+                reset_error_memory=reset_error_memory,
+            ),
+            async_request_refresh=AsyncMock(),
+            button_action_in_progress=False,
+            active_button_key=None,
+            last_update_success=True,
+            async_update_listeners=Mock(),
+        )
+
+        def set_active_button_action(button_key: str | None) -> None:
+            coordinator.button_action_in_progress = button_key is not None
+            coordinator.active_button_key = button_key
+            coordinator.async_update_listeners()
+
+        coordinator.set_active_button_action = set_active_button_action
+        entity = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="reset_error_memory",
+                    translation_key="reset_error_memory",
+                ),
+            ),
+        )
+
+        with self.assertRaises(RuntimeError):
+            await entity.async_press()
+
+        self.assertFalse(coordinator.button_action_in_progress)
+        self.assertIsNone(coordinator.active_button_key)
+        self.assertTrue(entity.available)
+
+    async def test_button_press_clears_busy_state_when_refresh_fails(self) -> None:
+        start_manual_regeneration = AsyncMock()
+        request_refresh = AsyncMock(side_effect=RuntimeError("refresh failed"))
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "0"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(
+                model="softliQ:SC18",
+                sw_version="1.0",
+                start_manual_regeneration=start_manual_regeneration,
+            ),
+            async_request_refresh=request_refresh,
+            button_action_in_progress=False,
+            active_button_key=None,
+            last_update_success=True,
+            async_update_listeners=Mock(),
+        )
+
+        def set_active_button_action(button_key: str | None) -> None:
+            coordinator.button_action_in_progress = button_key is not None
+            coordinator.active_button_key = button_key
+            coordinator.async_update_listeners()
+
+        coordinator.set_active_button_action = set_active_button_action
+        entity = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="manual_regeneration",
+                    translation_key="manual_regeneration",
+                ),
+            ),
+        )
+
+        with self.assertRaises(RuntimeError):
+            await entity.async_press()
+
+        start_manual_regeneration.assert_awaited_once()
+        request_refresh.assert_awaited_once()
+        self.assertFalse(coordinator.button_action_in_progress)
+        self.assertIsNone(coordinator.active_button_key)
+        self.assertTrue(entity.available)
+
+    async def test_button_press_rejects_second_action_while_busy(self) -> None:
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "0"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(
+                model="softliQ:SC18",
+                sw_version="1.0",
+                reset_error_memory=AsyncMock(),
+            ),
+            async_request_refresh=AsyncMock(),
+            button_action_in_progress=True,
+            active_button_key="manual_regeneration",
+            last_update_success=True,
+        )
+
+        entity = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="reset_error_memory",
+                    translation_key="reset_error_memory",
+                ),
+            ),
+        )
+
+        with self.assertRaises(HomeAssistantError):
+            await entity.async_press()
+
+        self.assertTrue(coordinator.button_action_in_progress)
+        self.assertEqual(coordinator.active_button_key, "manual_regeneration")
+
+    async def test_manual_regeneration_stays_unavailable_when_device_reports_running(
+        self,
+    ) -> None:
+        coordinator = make_coordinator_double(
+            data={"D_B_1": "1"},
+            config_entry=make_config_entry("Softener", "waterbox"),
+            client=make_client_double(model="softliQ:SC18", sw_version="1.0"),
+            async_request_refresh=AsyncMock(),
+            button_action_in_progress=False,
+            active_button_key=None,
+            last_update_success=True,
+        )
+
+        entity = SoftQLinkButtonEntity(
+            coordinator,
+            cast(
+                SoftQLinkButtonEntityDescription,
+                SimpleNamespace(
+                    key="manual_regeneration",
+                    translation_key="manual_regeneration",
+                ),
+            ),
+        )
+
+        self.assertFalse(entity.available)


### PR DESCRIPTION
refactor: centralize device info and unique-id handling for Gruenbeck entities
feat: disable Gruenbeck buttons while async actions are running
test: cover config migration, button busy state, and mux client error handling